### PR TITLE
Update RuleState.cs - Add IngameIcon to support DelveWall

### DIFF
--- a/State/RuleState.cs
+++ b/State/RuleState.cs
@@ -15,6 +15,8 @@ public class RuleState
     private readonly Lazy<NearbyMonsterInfo> _nearbyMonsterInfo;
     private readonly Lazy<List<EntityInfo>> _miscellaneousObjects;
     private readonly RuleInternalState _internalState;
+    private readonly Lazy<List<EntityInfo>> _ingameiconObjects; //adding icons for delve walls
+
     private readonly Lazy<List<EntityInfo>> _effects;
     private readonly Lazy<List<MonsterInfo>> _allMonsters;
 
@@ -73,6 +75,8 @@ public class RuleState
             _nearbyMonsterInfo = new Lazy<NearbyMonsterInfo>(() => new NearbyMonsterInfo(plugin), LazyThreadSafetyMode.None);
             _miscellaneousObjects = new Lazy<List<EntityInfo>>(() =>
                 controller.EntityListWrapper.ValidEntitiesByType[EntityType.MiscellaneousObjects].Select(x => new EntityInfo(controller, x)).ToList(), LazyThreadSafetyMode.None);
+            _ingameiconObjects = new Lazy<List<EntityInfo>>(() =>
+                controller.EntityListWrapper.ValidEntitiesByType[EntityType.IngameIcon].Select(x => new EntityInfo(controller, x)).ToList(), LazyThreadSafetyMode.None); //for delvewall
             _allMonsters = new Lazy<List<MonsterInfo>>(() =>
                 controller.EntityListWrapper.ValidEntitiesByType[EntityType.Monster].Select(x => new MonsterInfo(controller, x)).ToList(), LazyThreadSafetyMode.None);
             _effects = new Lazy<List<EntityInfo>>(() =>
@@ -146,6 +150,9 @@ public class RuleState
 
     [Api]
     public IEnumerable<EntityInfo> MiscellaneousObjects => _miscellaneousObjects.Value;
+
+    [Api]
+    public IEnumerable<EntityInfo> IngameIcons => _ingameiconObjects.Value;
 
     [Api]
     public IEnumerable<MonsterInfo> AllMonsters => _allMonsters.Value;


### PR DESCRIPTION
add IngameIcon (for DelveWall)

I just copied the syntax for MiscObjects, after finding out that apparently DelveWalls live in IngameIcon in GameController -> EntityListWrapper -> ValidEntitiesByType , the output for IngameIcon looks like this:



```
"IngameIcons": [
        {
            "Path": "Metadata/Terrain/Leagues/Delve/Objects/DelveWall",
            "BaseEntityPath": "Metadata/Terrain/Leagues/Delve/Objects/DelveWall.ao",
            "Position": {
                "X": 22114.13,
                "Y": 14755.435,
                "Z": 0.0,
                "IsNormalized": false,
                "IsZero": false
            },
            "Position2D": {
                "X": 22114.13,
                "Y": 14755.435,
                "IsNormalized": false,
                "IsZero": false
            },
            "DistanceToCursor": 166.4602,
            "Stats": {
                "AllStats": {
                    "VirtualOnFullLife": 1
                }
            },
            "IsAlive": true,
            "IsTargeted": false,
            "IsTargetable": true,
            "Distance": 98.731964
        }
    ],
```




If you wanted to active a key using the DelveWall, you could do something like this:

```
!Buffs.Has("grace_period") &&
SinceLastActivation(3) &&
(
Buffs["delve_degen_buff"].Charges >= 0
&& IngameIcons.Any(m => m.BaseEntityPath.Contains("DelveWall") 
&& m.DistanceToCursor <25 
&& m.Distance <50 
&& m.IsAlive == True )
)

```

