### PR TITLE
Added PlayerName, PlayerByName, AllPlayers

### DIFF
--- a/State/NearbyMonsterInfo.cs
+++ b/State/NearbyMonsterInfo.cs
@@ -62,6 +62,9 @@ public class EntityInfo
     [Api]
     public bool IsUsingAbility => Entity.TryGetComponent<Actor>(out var actor) && actor.Action == ActionFlags.UsingAbility;
 
+    [Api]
+    public string PlayerName => Entity.GetComponent<Player>()?.PlayerName ?? string.Empty;
+
 }
 
 [Api]

--- a/State/RuleState.cs
+++ b/State/RuleState.cs
@@ -19,6 +19,7 @@ public class RuleState
 
     private readonly Lazy<List<EntityInfo>> _effects;
     private readonly Lazy<List<MonsterInfo>> _allMonsters;
+    private readonly Lazy<List<MonsterInfo>> _allPlayers;
 
     public RuleInternalState InternalState
     {
@@ -81,6 +82,8 @@ public class RuleState
                 controller.EntityListWrapper.ValidEntitiesByType[EntityType.Monster].Select(x => new MonsterInfo(controller, x)).ToList(), LazyThreadSafetyMode.None);
             _effects = new Lazy<List<EntityInfo>>(() =>
                 controller.EntityListWrapper.ValidEntitiesByType[EntityType.Effect].Select(x => new EntityInfo(controller, x)).ToList(), LazyThreadSafetyMode.None);
+            _allPlayers = new Lazy<List<MonsterInfo>>(() =>
+                controller.EntityListWrapper.ValidEntitiesByType[EntityType.Player].Select(x => new MonsterInfo(controller, x)).ToList(), LazyThreadSafetyMode.None);
         }
     }
 
@@ -156,6 +159,12 @@ public class RuleState
 
     [Api]
     public IEnumerable<MonsterInfo> AllMonsters => _allMonsters.Value;
+
+    [Api]
+    public IEnumerable<MonsterInfo> AllPlayers => _allPlayers.Value;
+
+    [Api]
+    public MonsterInfo PlayerByName(string name) => _allPlayers.Value.FirstOrDefault(p=>p.PlayerName.Equals(name));
 
     [Api]
     public IEnumerable<EntityInfo> Effects => _effects.Value;


### PR DESCRIPTION
Added players related stuff. I'm not sure about PlayerByName, it can be null and checking for null would bloat the code for users (for example PlayerByName("test") == null ? false : !PlayerByName("test") .Buffs.Has("buffname")), maybe there is better solution. 

And AllPlayers has many uses, for example AllPlayers.Count(p=>p.Distance<30&&!p.Buffs.Has("buffname"))<6, I like it. Very useful in many cases: link skills/cry skills etc. Could work well to abuse vaal discipline uptime in party.